### PR TITLE
Fix unpacking process for the compressed folders 

### DIFF
--- a/lib/winrm/transport/file_transporter.rb
+++ b/lib/winrm/transport/file_transporter.rb
@@ -178,7 +178,6 @@ module WinRM
         debug { "Running check_files.ps1" }
         hash_file = create_remote_hash_file(check_files_ps_hash(files))
         vars = %{$hash_file = "#{hash_file}"\n}
-
         output = service.run_powershell_script(
           [vars, check_files_script].join("\n")
         )
@@ -253,7 +252,10 @@ module WinRM
           vars = %{$hash_file = "#{hash_file}"\n}
 
           output = service.run_powershell_script(
-            [vars, decode_files_script].join("\n")
+            [vars,
+             ". #{decode_files_script}",
+             "Decode-Files (Invoke-Input $hash_file) | ConvertTo-Csv -NoTypeInformation"
+            ].join("\n")
           )
           parse_response(output)
         end
@@ -376,7 +378,7 @@ module WinRM
         if obj.is_a?(Hash)
           obj.map { |k, v|
             %{#{pad(depth + 2)}#{ps_hash(k)} = #{ps_hash(v, depth + 2)}}
-          }.join("\n").insert(0, "@{\n").insert(-1, "\n#{pad(depth)}}")
+          }.join(";\n").insert(0, "@{\n").insert(-1, "\n#{pad(depth)}}")
         else
           %{"#{obj}"}
         end

--- a/spec/support/decode_files.Tests.ps1
+++ b/spec/support/decode_files.Tests.ps1
@@ -1,0 +1,43 @@
+. $PSScriptRoot\..\..\support\decode_files.ps1
+
+describe 'Decode-Base64File' {
+  context 'when given the hash map' {
+    $Content = 'QHsKICAiJGVudjpURU1QXGI2NC1mMWFlNGMyNzgwMWQ0NDMyNjliMjAyZTEyYWYyMDdkYS50eHQiID0gQHsKICAgICJkc3QiID0gIiRlbnY6VEVNUFxraXRjaGVuIgogICAgInRtcHppcCIgPSAiJGVudjpURU1QXHRtcHppcC1mMWFlNGMyNzgwMWQ0NDMyNjliMjAyZTEyYWYyMDdkYS56aXAiCiAgfQogICIkZW52OlRFTVBcYjY0LThjYzM5NDViZTA0NWZhNGY4YjAyZmFmM2I3ZDRjZGJkLnR4dCIgPSBAewogICAgImRzdCIgPSAiJGVudjpURU1QXGtpdGNoZW4iCiAgICAidG1wemlwIiA9ICIkZW52OlRFTVBcdG1wemlwLThjYzM5NDViZTA0NWZhNGY4YjAyZmFmM2I3ZDRjZGJkLnppcCIKICB9Cn0= '
+    $EncodedSource = "$env:temp\encoded.txt"
+    $DecodedDestination = "$env:temp\decoded.txt"
+    Set-Content $EncodedSource -value $content
+    Decode-Base64File $EncodedSource $DecodedDestination
+    $DecodedContent  = gc $DecodedDestination | out-string
+    $hash = invoke-expression $DecodedContent
+
+    it 'has two keys' {
+      $hash.keys.count | should be 2
+    }
+    it 'has a key that matches $env:TEMP\b64-f1ae4c27801d443269b202e12af207da.txt' {
+      $hash.keys |
+        where {$_ -like "$env:TEMP\b64-f1ae4c27801d443269b202e12af207da.txt"} |
+        should not be $null
+    }
+    it 'has keys with values including "dst" and "tmpzip"' {
+       $hash.keys |
+        where { -not ( ($hash[$_].keys -contains 'dst') -and
+          ($hash[$_].keys -contains 'tmpzip') ) } |
+        should be $null
+    }
+    rm $EncodedSource, $DecodedDestination
+  }
+}
+
+describe 'Test-IOCompression' {
+  context 'when PowerShell version is 3 or greater' {
+    it 'and .NET 4.5 client is present - use IO.Compression' {
+      mock Test-NETStack -mockwith {$true}
+      Test-IOCompression | should be $true
+    }
+    it 'and .NET 4.5 client is absent - use COM' {
+      mock Test-NETStack -mockwith {$false}
+      Test-IOCompression | should be $false
+    }
+  }
+}
+

--- a/spec/winrm/transport/file_transporter_spec.rb
+++ b/spec/winrm/transport/file_transporter_spec.rb
@@ -513,11 +513,12 @@ describe WinRM::Transport::FileTransporter do
       upload
     end
 
+    # FRAGILE TEST.  THERE IS A TRAILING SPACE AFTER the ';'
     it "uploads the hash_file in chunks for decode_files" do
       hash = outdent!(<<-HASH.chomp)
         @{
           "#{ps_tmpfile}" = @{
-            "dst" = "#{dst}"
+            "dst" = "#{dst}";
             "tmpzip" = "#{ps_tmpzip}"
           }
         }
@@ -664,11 +665,12 @@ describe WinRM::Transport::FileTransporter do
       upload
     end
 
+    # FRAGILE TEST.  THERE IS A TRAILING SPACE AFTER the ';'
     it "uploads the hash_file in chunks for check_files" do
       hash = outdent!(<<-HASH.chomp)
         @{
-          "#{dst1}" = "#{src1_md5}"
-          "#{dst2}" = "#{src2_md5}"
+          "#{dst1}" = "#{src1_md5}";
+          "#{dst2}" = "#{src2_md5}";
           "#{dst3}" = "#{src3_md5}"
         }
       HASH
@@ -711,12 +713,13 @@ describe WinRM::Transport::FileTransporter do
       upload
     end
 
+    # FRAGILE TEST.  THERE IS A TRAILING SPACE AFTER the ';'
     it "uploads the hash_file in chunks for decode_files" do
       hash = outdent!(<<-HASH.chomp)
         @{
           "#{ps1_tmpfile}" = @{
             "dst" = "#{dst1}"
-          }
+          };
           "#{ps2_tmpfile}" = @{
             "dst" = "#{dst2}"
           }

--- a/spec/winrm/transport/file_transporter_spec.rb
+++ b/spec/winrm/transport/file_transporter_spec.rb
@@ -513,7 +513,6 @@ describe WinRM::Transport::FileTransporter do
       upload
     end
 
-    # FRAGILE TEST.  THERE IS A TRAILING SPACE AFTER the ';'
     it "uploads the hash_file in chunks for decode_files" do
       hash = outdent!(<<-HASH.chomp)
         @{
@@ -665,7 +664,6 @@ describe WinRM::Transport::FileTransporter do
       upload
     end
 
-    # FRAGILE TEST.  THERE IS A TRAILING SPACE AFTER the ';'
     it "uploads the hash_file in chunks for check_files" do
       hash = outdent!(<<-HASH.chomp)
         @{
@@ -713,7 +711,6 @@ describe WinRM::Transport::FileTransporter do
       upload
     end
 
-    # FRAGILE TEST.  THERE IS A TRAILING SPACE AFTER the ';'
     it "uploads the hash_file in chunks for decode_files" do
       hash = outdent!(<<-HASH.chomp)
         @{

--- a/support/decode_files.ps1
+++ b/support/decode_files.ps1
@@ -20,7 +20,7 @@ Function Decode-Files($hash) {
     $tzip, $dst = (Unresolve-Path $_.Value["tmpzip"]), (Unresolve-Path $_.Value["dst"])
     $decoded = if ($tzip -ne $null) { $tzip } else { $dst }
     Decode-Base64File $tmp $decoded
-    Remove-Item $tmp -Force
+    #Remove-Item $tmp -Force
     $dMd5 = Get-MD5Sum $decoded
     $verifies = if ($sMd5 -eq $dMd5) { $true } else { $false }
     if ($tzip) { Unzip-File $tzip $dst; Remove-Item $tzip -Force }

--- a/support/decode_files.ps1
+++ b/support/decode_files.ps1
@@ -14,7 +14,7 @@ Function Decode-Files($hash) {
     $sMd5 = (Get-Item $tmp).BaseName.Replace("b64-", "")
     $decoded = if ($tzip -ne $null) { $tzip } else { $dst }
     Decode-Base64File $tmp $decoded
-    #Remove-Item $tmp -Force
+    Remove-Item $tmp -Force
     $dMd5 = Get-MD5Sum $decoded
     $verifies = $sMd5 -like $dMd5
     if ($tzip) {Unzip-File $tzip $dst;Remove-Item $tzip -Force}

--- a/support/decode_files.ps1
+++ b/support/decode_files.ps1
@@ -1,60 +1,50 @@
-Function Cleanup($o) { if (($o -ne $null) -and ($o.GetType().GetMethod("Dispose") -ne $null)) { $o.Dispose() } }
-
-Function Decode-Base64File($src, $dst) {
-  Try {
-    $in = (Get-Item $src).OpenRead()
-    $b64 = New-Object -TypeName System.Security.Cryptography.FromBase64Transform
-    $m = [System.Security.Cryptography.CryptoStreamMode]::Read
-    $d = New-Object -TypeName System.Security.Cryptography.CryptoStream $in,$b64,$m
-    echo $null > $dst
-    Copy-Stream $d ($out = [System.IO.File]::OpenWrite($dst))
-  } Finally { Cleanup $in; Cleanup $out; Cleanup $d }
-}
-
+Function Cleanup($o) { if (($o) -and ($o.GetType().GetMethod("Dispose") -ne $null)) { $o.Dispose() } }
+Function Decode-Base64File($src, $dst) {set-content -Encoding Byte -Path $dst -Value ([Convert]::FromBase64String([IO.File]::ReadAllLines($src)))}
 Function Copy-Stream($src, $dst) { $b = New-Object Byte[] 4096; while (($i = $src.Read($b, 0, $b.Length)) -ne 0) { $dst.Write($b, 0, $i) } }
+function Resolve-ProviderPath{ $input | % {if ($_){(Resolve-Path $_).ProviderPath} else{$null}} }
+Function Release-COM($o) { if ($o -ne $null) { [void][Runtime.Interopservices.Marshal]::ReleaseComObject($o) } }
+function Test-NETStack($Version, $r = 'HKLM:\Software\Microsoft\NET Framework Setup\NDP\v4') { [bool]("$r\Full", "$r\Client" | ? {(gp $_).Version -like "$($Version)*"}) }
+function Test-IOCompression {($PSVersionTable.PSVersion.Major -ge 3) -and (Test-NETStack '4.5')}
+set-alias RPP -Value Resolve-ProviderPath
 
 Function Decode-Files($hash) {
-  $hash.GetEnumerator() | ForEach-Object {
-    $tmp = Unresolve-Path $_.Key
+  foreach ($key in $hash.keys) {
+    $value = $hash[$key]
+    $tmp, $tzip, $dst = $Key, $Value["tmpzip"], $Value["dst"]
     $sMd5 = (Get-Item $tmp).BaseName.Replace("b64-", "")
-    $tzip, $dst = (Unresolve-Path $_.Value["tmpzip"]), (Unresolve-Path $_.Value["dst"])
     $decoded = if ($tzip -ne $null) { $tzip } else { $dst }
     Decode-Base64File $tmp $decoded
     #Remove-Item $tmp -Force
     $dMd5 = Get-MD5Sum $decoded
-    $verifies = if ($sMd5 -eq $dMd5) { $true } else { $false }
-    if ($tzip) { Unzip-File $tzip $dst; Remove-Item $tzip -Force }
+    $verifies = $sMd5 -like $dMd5
+    if ($tzip) {Unzip-File $tzip $dst;Remove-Item $tzip -Force}
     New-Object psobject -Property @{ dst = $dst; verifies = $verifies; src_md5 = $sMd5; dst_md5 = $dMd5; tmpfile = $tmp; tmpzip = $tzip }
-  } | Select-Object -Property dst,verifies,src_md5,dst_md5,tmpfile,tmpzip
+  }
 }
 
 Function Get-MD5Sum($src) {
   Try {
-    $c = New-Object -TypeName System.Security.Cryptography.MD5CryptoServiceProvider
+    $c = New-Object -TypeName Security.Cryptography.MD5CryptoServiceProvider
     $bytes = $c.ComputeHash(($in = (Get-Item $src).OpenRead()))
-    return ([System.BitConverter]::ToString($bytes)).Replace("-", "").ToLower()
-  } Finally { Cleanup $c; Cleanup $in }
+    ([BitConverter]::ToString($bytes)).Replace("-", "").ToLower()
+  } catch [exception]{throw $_} finally { Cleanup $c; Cleanup $in }
 }
 
 Function Invoke-Input($in) {
-  $in = Unresolve-Path $in
+  $in = $in | rpp
   Decode-Base64File $in ($decoded = "$($in).ps1")
   $expr = Get-Content $decoded | Out-String
   Remove-Item $in,$decoded -Force
-  return Invoke-Expression "$expr"
+  Invoke-Expression "$expr"
 }
-
-Function Release-COM($o) { if ($o -ne $null) { [void][System.Runtime.Interopservices.Marshal]::ReleaseComObject($o) } }
-
-Function Unresolve-Path($p) { if ($p -eq $null) { return $null } else { return $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($p) } }
 
 Function Unzip-File($src, $dst) {
-  $r = "HKLM:\Software\Microsoft\NET Framework Setup\NDP\v4"
-  if (($PSVersionTable.PSVersion.Major -ge 3) -and ((gp "$r\Full").Version -like "4.5*" -or (gp "$r\Client").Version -like "4.5*")) {
-    [System.Reflection.Assembly]::LoadWithPartialName("System.IO.Compression.FileSystem") | Out-Null; [System.IO.Compression.ZipFile]::ExtractToDirectory("$src", "$dst")
-  } else {
-    Try { $s = New-Object -ComObject Shell.Application; ($dp = $s.NameSpace($dst)).CopyHere(($z = $s.NameSpace($src)).Items(), 0x610) } Finally { Release-Com $s; Release-Com $z; Release-COM $dp }
+  $unpack = $src -replace '\.zip'
+  if (Test-IOCompression) {Add-Type -AN System.IO.Compression.FileSystem; [IO.Compression.ZipFile]::ExtractToDirectory($src, $unpack)}
+  else {
+    Try {$s = New-Object -ComObject Shell.Application; ($dp = $s.NameSpace($unpack)).CopyHere(($z = $s.NameSpace($src)).Items(), 0x610)} Finally {Release-Com $s; Release-Com $z; Release-COM $dp}
   }
+  if (-not (test-path $dst)) {$null = mkdir $dst }
+  dir $unpack | cp -dest "$dst/" -force -recurse
+  rm $unpack -recurse -force
 }
-
-Decode-Files (Invoke-Input $hash_file) | ConvertTo-Csv -NoTypeInformation


### PR DESCRIPTION
Currently, when files are updated locally and a new kitchen action is taken, the files on the remote node are not updated.  This PR changes the unpacking and relocation of the files to make sure that new and updated files are moved into the proper locations.

I've also started adding Pester tests to the supporting PowerShell functions.
