### PR TITLE
Remove fakefs as a development dependency.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,22 +35,6 @@ elsif ENV["COVERAGE"]
   SimpleCov.start "gem"
 end
 
-require "fakefs/safe"
 require "minitest/autorun"
 require "mocha/setup"
 require "tempfile"
-
-# Nasty hack to redefine IO.read in terms of File#read for fakefs
-class IO
-  def self.read(*args)
-    File.open(args[0], "rb") { |f| f.read(args[1]) }
-  end
-end
-
-def with_fake_fs
-  FakeFS.activate!
-  FileUtils.mkdir_p("/tmp")
-  yield
-  FakeFS.deactivate!
-  FakeFS::FileSystem.clear
-end

--- a/winrm-transport.gemspec
+++ b/winrm-transport.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler",    "~> 1.9"
   spec.add_development_dependency "rake",       "~> 10.0"
 
-  spec.add_development_dependency "fakefs",     "~> 0.4"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "mocha",      "~> 1.1"
 


### PR DESCRIPTION
As this code was extracted from test-kitchen, this gem and setup came
along for the ride. It appears to not currently be in use.
