### PR TITLE
#642 unzip cookbooks

### DIFF
--- a/lib/winrm/transport/file_transporter.rb
+++ b/lib/winrm/transport/file_transporter.rb
@@ -251,11 +251,15 @@ module WinRM
           hash_file = create_remote_hash_file(decoded_files)
           vars = %{$hash_file = "#{hash_file}"\n}
 
+          # https://github.com/test-kitchen/test-kitchen/issues/625
+          # https://github.com/test-kitchen/test-kitchen/issues/642
+          # Rather do not add comments to ps1 scripts, because then
+          # you'd probably get "The command line is too long" error.
+          # CopyHere options are 0x610, which is decimal: 1552 = 16 + 512 + 1024
+          # https://msdn.microsoft.com/en-us/library/windows/desktop/bb787866%28v=vs.85%29.aspx
+          # Release-Com method used to free the underlying COM objects.
           output = service.run_powershell_script(
-            [vars,
-             ". #{decode_files_script}",
-             "Decode-Files (Invoke-Input $hash_file) | ConvertTo-Csv -NoTypeInformation"
-            ].join("\n")
+          [vars, decode_files_script].join("\n")
           )
           parse_response(output)
         end

--- a/lib/winrm/transport/file_transporter.rb
+++ b/lib/winrm/transport/file_transporter.rb
@@ -359,7 +359,7 @@ module WinRM
       # @return [String] parsed clixml into String
       def clixml_to_s(clixml)
         doc = REXML::Document.new(clixml)
-        text = doc.get_elements('//S').map(&:text).join
+        text = doc.get_elements("//S").map(&:text).join
         text.gsub(/_x(\h\h\h\h)_/) do
           code = Regexp.last_match[1]
           code.hex.chr
@@ -376,18 +376,18 @@ module WinRM
       def parse_response(output)
         exitcode = output[:exitcode]
         stderr = output.stderr
-        if stderr.include?('The command line is too long')
+        if stderr.include?("The command line is too long")
           # The powershell script which should result in `output` parameter
           # is too long, remove some newlines, comments, etc from it.
-          raise StandardError, 'The command line is too long' \
-            ' (powershell script is too long)'
+          raise StandardError, "The command line is too long" \
+            " (powershell script is too long)"
         end
         pretty_stderr = clixml_to_s(stderr)
 
         if exitcode != 0
           raise FileTransporterFailed, "[#{self.class}] Upload failed " \
             "(exitcode: #{exitcode})\n#{pretty_stderr}"
-        elsif stderr != '\r\n' && stderr != ''
+        elsif stderr != '\r\n' && stderr != ""
           raise FileTransporterFailed, "[#{self.class}] Upload failed " \
             "(exitcode: 0), but stderr present\n#{pretty_stderr}"
         end

--- a/support/decode_files.ps1
+++ b/support/decode_files.ps1
@@ -1,10 +1,10 @@
 Function Cleanup($o) { if (($o) -and ($o.GetType().GetMethod("Dispose") -ne $null)) { $o.Dispose() } }
 Function Decode-Base64File($src, $dst) {set-content -Encoding Byte -Path $dst -Value ([Convert]::FromBase64String([IO.File]::ReadAllLines($src)))}
 Function Copy-Stream($src, $dst) { $b = New-Object Byte[] 4096; while (($i = $src.Read($b, 0, $b.Length)) -ne 0) { $dst.Write($b, 0, $i) } }
-function Resolve-ProviderPath{ $input | % {if ($_){(Resolve-Path $_).ProviderPath} else{$null}} }
+Function Resolve-ProviderPath{ $input | % {if ($_){(Resolve-Path $_).ProviderPath} else{$null}} }
 Function Release-COM($o) { if ($o -ne $null) { [void][Runtime.Interopservices.Marshal]::ReleaseComObject($o) } }
-function Test-NETStack($Version, $r = 'HKLM:\Software\Microsoft\NET Framework Setup\NDP\v4') { [bool]("$r\Full", "$r\Client" | ? {(gp $_).Version -like "$($Version)*"}) }
-function Test-IOCompression {($PSVersionTable.PSVersion.Major -ge 3) -and (Test-NETStack '4.5')}
+Function Test-NETStack($Version, $r = 'HKLM:\Software\Microsoft\NET Framework Setup\NDP\v4') { [bool]("$r\Full", "$r\Client" | ? {(gp $_).Version -like "$($Version)*"}) }
+Function Test-IOCompression {($PSVersionTable.PSVersion.Major -ge 3) -and (Test-NETStack '4.5')}
 set-alias RPP -Value Resolve-ProviderPath
 
 Function Decode-Files($hash) {
@@ -39,12 +39,22 @@ Function Invoke-Input($in) {
 }
 
 Function Unzip-File($src, $dst) {
-  $unpack = $src -replace '\.zip'
-  if (Test-IOCompression) {Add-Type -AN System.IO.Compression.FileSystem; [IO.Compression.ZipFile]::ExtractToDirectory($src, $unpack)}
-  else {
-    Try {$s = New-Object -ComObject Shell.Application; ($dp = $s.NameSpace($unpack)).CopyHere(($z = $s.NameSpace($src)).Items(), 0x610)} Finally {Release-Com $s; Release-Com $z; Release-COM $dp}
+  if (Test-IOCompression) {
+    $unpack = $src -replace '\.zip'
+    Add-Type -AN System.IO.Compression.FileSystem; [IO.Compression.ZipFile]::ExtractToDirectory($src, $unpack)
+    if (-not (test-path $dst)) {$null = mkdir $dst }
+    dir $unpack | cp -dest "$dst/" -force -recurse
+    rm $unpack -recurse -force
   }
-  if (-not (test-path $dst)) {$null = mkdir $dst }
-  dir $unpack | cp -dest "$dst/" -force -recurse
-  rm $unpack -recurse -force
+  else {
+    Try {
+      $shell = New-Object -ComObject Shell.Application;
+      $zip = $shell.NameSpace($src)
+      $destination_dir = $shell.NameSpace($dst)
+      foreach($item in $zip.Items()) {$destination_dir.CopyHere($item, 0x610)}
+    }
+    Finally { Release-Com $shell; Release-Com $zip; Release-COM $destination_dir }
+  }
 }
+
+Decode-Files (Invoke-Input $hash_file) | ConvertTo-Csv -NoTypeInformation


### PR DESCRIPTION
First commit makes working with powershell scripts outputs easier, does not change any logic, only shows error messages prettier and, in some cases, shows at all (in relation to previous behavior). I really think it should go to master.

Second commit fixes the https://github.com/test-kitchen/test-kitchen/issues/642 issue. Without it, the directory `cookbooks` was not unzipped from tmpzip-{hash}.zip file. I tested on Windows 7 only. It may need further testing on other Windows versions.

There is still another bug I see, but did not fix:  once `dna.json` and `solo.rb` are transferred to Windows vm on `kitchen converge`, they are not updated on next `kitchen converge`. I did not fix it, because it does not bother me and I actually did not go deep through the MD5 functions here. 
