### PR TITLE
Added tests and fix for non-empty stderr bug - https://github.com/tes…

### DIFF
--- a/lib/winrm/transport/file_transporter.rb
+++ b/lib/winrm/transport/file_transporter.rb
@@ -383,7 +383,7 @@ module WinRM
         if exitcode != 0
           raise FileTransporterFailed, "[#{self.class}] Upload failed " \
             "(exitcode: #{exitcode})\n#{pretty_stderr}"
-        elsif stderr != '\r\n' && stderr != ""
+        elsif pretty_stderr != '\r\n' && pretty_stderr != ""
           raise FileTransporterFailed, "[#{self.class}] Upload failed " \
             "(exitcode: 0), but stderr present\n#{pretty_stderr}"
         end

--- a/spec/winrm/transport/file_transporter_spec.rb
+++ b/spec/winrm/transport/file_transporter_spec.rb
@@ -253,6 +253,20 @@ describe WinRM::Transport::FileTransporter do
             "Upload failed (exitcode: 10)", :partial_line)
         end
       end
+      
+      describe "when a valid check is returned with information in the output but no errors" do
+
+        def check_output
+          o = ::WinRM::Output.new
+          o[:exitcode] = 0
+          o[:data].concat([{ :stderr => "Oh noes\n" }])
+          o
+        end
+   
+        it "no errors raised" do
+          upload.wont_be_nil
+        end
+      end
 
       describe "when a failed decode command is returned" do
 
@@ -269,6 +283,19 @@ describe WinRM::Transport::FileTransporter do
           }.must_raise WinRM::Transport::FileTransporterFailed
           err.message.must_match regexify(
             "Upload failed (exitcode: 10)", :partial_line)
+        end
+      end
+      describe "when a valid decode command is returned with information in the output but no errors" do
+
+        def decode_output
+          o = ::WinRM::Output.new
+          o[:exitcode] = 0
+          o[:data].concat([{ :stderr => "Oh noes\n" }])
+          o
+        end
+   
+        it "no errors raised" do
+          upload.wont_be_nil
         end
       end
     end
@@ -584,6 +611,19 @@ describe WinRM::Transport::FileTransporter do
           "Upload failed (exitcode: 10)", :partial_line)
       end
     end
+    describe "when a valid check command is returned with information in the output but no errors" do
+
+      def check_output
+        o = ::WinRM::Output.new
+        o[:exitcode] = 0
+        o[:data].concat([{ :stderr => "Oh noes\n" }])
+        o
+      end
+  
+      it "no errors raised" do
+        upload.wont_be_nil
+      end
+    end
 
     describe "when a failed decode command is returned" do
 
@@ -600,6 +640,19 @@ describe WinRM::Transport::FileTransporter do
         }.must_raise WinRM::Transport::FileTransporterFailed
         err.message.must_match regexify(
           "Upload failed (exitcode: 10)", :partial_line)
+      end
+    end
+    describe "when a valid decode command is returned with information in the output but no errors" do
+
+      def decode_output
+        o = ::WinRM::Output.new
+        o[:exitcode] = 0
+        o[:data].concat([{ :stderr => "Oh noes\n" }])
+        o
+      end
+  
+      it "no errors raised" do
+        upload.wont_be_nil
       end
     end
   end
@@ -801,6 +854,19 @@ describe WinRM::Transport::FileTransporter do
           "Upload failed (exitcode: 10)", :partial_line)
       end
     end
+    describe "when a valid check command is returned with information in the output but no errors" do
+
+      def check_output
+        o = ::WinRM::Output.new
+        o[:exitcode] = 0
+        o[:data].concat([{ :stderr => "Oh noes\n" }])
+        o
+      end
+  
+      it "no errors raised" do
+        upload.wont_be_nil
+      end
+    end
 
     describe "when a failed decode command is returned" do
 
@@ -817,6 +883,19 @@ describe WinRM::Transport::FileTransporter do
         }.must_raise WinRM::Transport::FileTransporterFailed
         err.message.must_match regexify(
           "Upload failed (exitcode: 10)", :partial_line)
+      end
+    end
+    describe "when a valid check command is returned with information in the output but no errors" do
+
+      def decode_output
+        o = ::WinRM::Output.new
+        o[:exitcode] = 0
+        o[:data].concat([{ :stderr => "Oh noes\n" }])
+        o
+      end
+  
+      it "no errors raised" do
+        upload.wont_be_nil
       end
     end
   end

--- a/spec/winrm/transport/file_transporter_spec.rb
+++ b/spec/winrm/transport/file_transporter_spec.rb
@@ -253,8 +253,7 @@ describe WinRM::Transport::FileTransporter do
             "Upload failed (exitcode: 10)", :partial_line)
         end
       end
-      
-      describe "when a valid check is returned with information in the output but no errors" do
+      describe "when a valid check is returned with info in the output but no errors" do
 
         def check_output
           o = ::WinRM::Output.new
@@ -262,7 +261,6 @@ describe WinRM::Transport::FileTransporter do
           o[:data].concat([{ :stderr => "Oh noes\n" }])
           o
         end
-   
         it "no errors raised" do
           upload.wont_be_nil
         end
@@ -285,7 +283,7 @@ describe WinRM::Transport::FileTransporter do
             "Upload failed (exitcode: 10)", :partial_line)
         end
       end
-      describe "when a valid decode command is returned with information in the output but no errors" do
+      describe "when a valid decode command is returned with info in the output but no errors" do
 
         def decode_output
           o = ::WinRM::Output.new
@@ -293,7 +291,6 @@ describe WinRM::Transport::FileTransporter do
           o[:data].concat([{ :stderr => "Oh noes\n" }])
           o
         end
-   
         it "no errors raised" do
           upload.wont_be_nil
         end
@@ -611,7 +608,7 @@ describe WinRM::Transport::FileTransporter do
           "Upload failed (exitcode: 10)", :partial_line)
       end
     end
-    describe "when a valid check command is returned with information in the output but no errors" do
+    describe "when a valid check command is returned with info in the output but no errors" do
 
       def check_output
         o = ::WinRM::Output.new
@@ -619,7 +616,6 @@ describe WinRM::Transport::FileTransporter do
         o[:data].concat([{ :stderr => "Oh noes\n" }])
         o
       end
-  
       it "no errors raised" do
         upload.wont_be_nil
       end
@@ -642,7 +638,7 @@ describe WinRM::Transport::FileTransporter do
           "Upload failed (exitcode: 10)", :partial_line)
       end
     end
-    describe "when a valid decode command is returned with information in the output but no errors" do
+    describe "when a valid decode command is returned with info in the output but no errors" do
 
       def decode_output
         o = ::WinRM::Output.new
@@ -650,7 +646,6 @@ describe WinRM::Transport::FileTransporter do
         o[:data].concat([{ :stderr => "Oh noes\n" }])
         o
       end
-  
       it "no errors raised" do
         upload.wont_be_nil
       end
@@ -854,7 +849,7 @@ describe WinRM::Transport::FileTransporter do
           "Upload failed (exitcode: 10)", :partial_line)
       end
     end
-    describe "when a valid check command is returned with information in the output but no errors" do
+    describe "when a valid check command is returned with info in the output but no errors" do
 
       def check_output
         o = ::WinRM::Output.new
@@ -862,7 +857,6 @@ describe WinRM::Transport::FileTransporter do
         o[:data].concat([{ :stderr => "Oh noes\n" }])
         o
       end
-  
       it "no errors raised" do
         upload.wont_be_nil
       end
@@ -885,7 +879,7 @@ describe WinRM::Transport::FileTransporter do
           "Upload failed (exitcode: 10)", :partial_line)
       end
     end
-    describe "when a valid check command is returned with information in the output but no errors" do
+    describe "when a valid check command is returned with info in the output but no errors" do
 
       def decode_output
         o = ::WinRM::Output.new
@@ -893,7 +887,6 @@ describe WinRM::Transport::FileTransporter do
         o[:data].concat([{ :stderr => "Oh noes\n" }])
         o
       end
-  
       it "no errors raised" do
         upload.wont_be_nil
       end


### PR DESCRIPTION
Found this issue after upgrading to PowerShell 5 Production Preview.  See related issue - https://github.com/test-kitchen/winrm-transport/issues/14

It looks like this new version of PowerShell 5 adds addition information to the standard error output even when there aren't any errors.  This highlighted what I believe is a bug in the parse_response method in the file_transporter.  The if condition was checking the raw PowerShell output instead of the "pretty" output.

This is my first Ruby PR so go easy on me.  Hope this helps.
