### PR TITLE
bumping to 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.2 / 2015-11-10
+
+### Bug fixes
+
+* Pull request [#15][]: Fixes file transfer to windows instances running WMF 5. ([@smurawski][])
+
 ## 1.0.2 / 2015-06-24
 
 ### Bug fixes

--- a/lib/winrm/transport/version.rb
+++ b/lib/winrm/transport/version.rb
@@ -20,6 +20,6 @@ module WinRM
 
   module Transport
 
-    VERSION = "1.0.3.dev"
+    VERSION = "1.0.3"
   end
 end


### PR DESCRIPTION
Can we release @smurawski 's change which fixes file transfers to windows test instances running WMF 5?

cc @test-kitchen/windows 
