### PR TITLE
retry if an 'Illegal operation attempted on a registry key that has been marked for deletion" fault occurs when opening a remote shell

### DIFF
--- a/lib/winrm/transport/command_executor.rb
+++ b/lib/winrm/transport/command_executor.rb
@@ -80,11 +80,14 @@ module WinRM
         begin
           @shell = service.open_shell
         rescue WinRMWSManFault => e
-          raise unless e.fault_description.include?('Illegal operation attempted on a registry key that has been marked for deletion') && attempt < MAX_RETRIES
-          debug { "Retrying open_shell call due to the following fault: fault_code = #{e.fault_code}; fault_description = #{e.fault_description}" }
+          fault = "Illegal operation attempted on a registry key that has been marked for deletion"
+          raise unless e.fault_description.include?(fault) && attempt < MAX_RETRIES
+          debug {
+            "Retry open_shell: fault_code=#{e.fault_code};fault_description=#{e.fault_description}"
+          }
 
           attempt += 1
-          debug { "sleeping #{SLEEP_SECONDS} seconds before retry"}
+          debug { "sleeping #{SLEEP_SECONDS} seconds before retry" }
           sleep SLEEP_SECONDS
           retry
         end

--- a/spec/winrm/transport/command_executor_spec.rb
+++ b/spec/winrm/transport/command_executor_spec.rb
@@ -118,11 +118,12 @@ describe WinRM::Transport::CommandExecutor do
     describe "when a registry key marked for deletion fault occurs" do
 
       let(:fault) do
-        fault_description = %q{<f:WSManFault Code='2147943418' Machine='localhost' xmlns:f='http://schemas.microsoft.com/wbem/wsman/1/wsmanfault'><f:Message><f:ProviderFault path='%systemroot%\system32\winrscmd.dll' provider='Shell cmd plugin'>Illegal operation attempted on a registry key that has been marked for deletion. </f:ProviderFault></f:Message></f:WSManFault>}
-        ::WinRM::WinRMWSManFault.new(fault_description, 2147943418)
+        msg = "Illegal operation attempted on a registry key that has been marked for deletion"
+        code = 2147943418 # the fault code returned by windows when this error occurs
+        ::WinRM::WinRMWSManFault.new(msg, code)
       end
 
-      let(:max_tries) { 5 }  # 5 because it's 4 retries, meaning the original attempt, plus 4 additional re-attempts
+      let(:max_tries) { ::WinRM::Transport::CommandExecutor::MAX_RETRIES + 1 }
 
       before do
         service.unstub(:open_shell)


### PR DESCRIPTION
Fixes #18 
